### PR TITLE
feature(mockGraphql) now you can pass an array of responses for an operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,23 @@ beforeEach(() => {
   cy.server();
   cy.mockGraphql({
     schema,
-    endpoint: '/gql'
+    endpoint: '/gql',
+    operations: {
+      User: { userQuery: { name: "user"} },
+      ValidateUser: [
+        { validateQuery: {isValid: false} },
+        { validateQuery: {isValid: true} }
+      ],
+      Hello: variables => ({ helloQuery: {message: `Hello ${varibales.name}`} })
+    }
   });
 });
 ```
 
 It takes an "operations" object, representing the named operations
-of the GraphQL server. This is combined with the "mocks" option,
+of the GraphQL server. An operation can be Object, Function or Array (for multiple call).
+In case of Array, the order of the elements must fit the order of the calls.
+This is combined with the "mocks" option,
 to modify the output behavior per test.
 
 The `.mockGraphqlOps()` allows you to configure the mock responses at a

--- a/src/index.ts
+++ b/src/index.ts
@@ -167,5 +167,14 @@ function getRootValue<AllOperations>(
   if (typeof op === "function") {
     return op(variables);
   }
+  if (Array.isArray(op)) {
+    if (op.length > 0) {
+      return op.shift();
+    } else {
+      throw Error(
+        `No more stub for the operation "${operationName}"! Check your stubs array for this operation.`
+      );
+    }
+  }
   return op;
 }


### PR DESCRIPTION
This PR adds the possibility of passing an Array of stubs for a graphql operation. The order of the stubs must be the order of graphql calls.